### PR TITLE
fix json editor initial firing bug

### DIFF
--- a/client/components/JsonEditor/index.js
+++ b/client/components/JsonEditor/index.js
@@ -11,8 +11,12 @@ export default class JsonEditor extends Component {
     super(...args);
     let { value } = this.props;
     value = formatJson.plain(value);
-
     this.state = { value };
+  }
+
+  componentDidMount () {
+    const mockedEvt = { target: { value: this.state.value } };
+    this.onChange(mockedEvt);
   }
 
   componentWillReceiveProps (nextProps) {


### PR DESCRIPTION
when switching to json mode and submitting form BEFORE making a change, it throws an error because parsedValue isn't set