### PR TITLE
static propTypes (code style)

### DIFF
--- a/client/components-compositors/Animated/children.js
+++ b/client/components-compositors/Animated/children.js
@@ -37,11 +37,12 @@ export default class AnimateChildren extends Component {
 
     return children;
   }
-}
 
-AnimateChildren.propTypes = {
-  children: PropTypes.any.isRequired,
-  pathname: PropTypes.string,
-  isView: PropTypes.bool,
-  absolute: PropTypes.bool
-};
+  static propTypes = {
+    children: PropTypes.any.isRequired,
+    pathname: PropTypes.string,
+    isView: PropTypes.bool,
+    absolute: PropTypes.bool
+  }
+
+}

--- a/client/components/AutoComplete/AutoComplete.js
+++ b/client/components/AutoComplete/AutoComplete.js
@@ -9,20 +9,20 @@ export default class WrappedAutoComplete extends Component {
     );
   }
 
+  static defaultProps = {
+    openOnFocus: true,
+    filter: (searchText, key) => searchText === '' || key.toLowerCase().indexOf(searchText.toLowerCase()) !== -1
+  }
+
+  static propTypes = {
+    dataSource: PropTypes.array.isRequired,
+    filter: PropTypes.func,
+    name: PropTypes.string.isRequired,
+    openOnFocus: PropTypes.bool
+  }
+
+  static contextTypes = {
+    muiTheme: PropTypes.object.isRequired
+  }
+
 }
-
-WrappedAutoComplete.defaultProps = {
-  openOnFocus: true,
-  filter: (searchText, key) => searchText === '' || key.toLowerCase().indexOf(searchText.toLowerCase()) !== -1
-};
-
-WrappedAutoComplete.propTypes = {
-  dataSource: PropTypes.array.isRequired,
-  filter: PropTypes.func,
-  name: PropTypes.string.isRequired,
-  openOnFocus: PropTypes.bool
-};
-
-WrappedAutoComplete.contextTypes = {
-  muiTheme: PropTypes.object.isRequired
-};

--- a/client/components/Box/Box.js
+++ b/client/components/Box/Box.js
@@ -22,10 +22,11 @@ export default class Box extends Component {
       </div>
     );
   }
-}
 
-Box.propTypes = {
-  title: PropTypes.string.isRequired,
-  value: PropTypes.string,
-  children: PropTypes.element
-};
+  static propTypes = {
+    title: PropTypes.string.isRequired,
+    value: PropTypes.string,
+    children: PropTypes.element
+  }
+
+}

--- a/client/components/Debug/Debug.js
+++ b/client/components/Debug/Debug.js
@@ -3,7 +3,7 @@ import React, { Component, PropTypes } from 'react';
 
 import style from './style.css';
 
-class Debug extends Component {
+export default class Debug extends Component {
 
   render () {
     return (
@@ -48,24 +48,22 @@ class Debug extends Component {
     this.props.actions.updateDevLogging(!this.props.debug.logging);
   }
 
+  static propTypes = {
+    actions: PropTypes.shape({
+      removeDevLogs: PropTypes.func.isRequired,
+      updateDevLogging: PropTypes.func.isRequired
+    }).isRequired,
+    debug: PropTypes.shape({
+      levels: PropTypes.string.isRequired,
+      logging: PropTypes.bool.isRequired,
+      logs: PropTypes.arrayOf(PropTypes.string).isRequired
+    }).isRequired,
+    status: PropTypes.shape({
+      name: PropTypes.string,
+      bestBlock: PropTypes.string.isRequired,
+      hashrate: PropTypes.string.isRequired,
+      peers: PropTypes.number.isRequired
+    }).isRequired
+  }
+
 }
-
-Debug.propTypes = {
-  actions: PropTypes.shape({
-    removeDevLogs: PropTypes.func.isRequired,
-    updateDevLogging: PropTypes.func.isRequired
-  }).isRequired,
-  debug: PropTypes.shape({
-    levels: PropTypes.string.isRequired,
-    logging: PropTypes.bool.isRequired,
-    logs: PropTypes.arrayOf(PropTypes.string).isRequired
-  }).isRequired,
-  status: PropTypes.shape({
-    name: PropTypes.string,
-    bestBlock: PropTypes.string.isRequired,
-    hashrate: PropTypes.string.isRequired,
-    peers: PropTypes.number.isRequired
-  }).isRequired
-};
-
-export default Debug;

--- a/client/components/EditableValue/EditableValue.js
+++ b/client/components/EditableValue/EditableValue.js
@@ -168,13 +168,13 @@ export default class EditableValue extends Component {
     );
   }
 
-}
+  static propTypes = {
+    onSubmit: PropTypes.func.isRequired,
+    value: PropTypes.string,
+    defaultValue: PropTypes.string,
+    children: PropTypes.element,
+    autocomplete: PropTypes.bool,
+    dataSource: PropTypes.arrayOf(PropTypes.string)
+  }
 
-EditableValue.propTypes = {
-  onSubmit: PropTypes.func.isRequired,
-  value: PropTypes.string,
-  defaultValue: PropTypes.string,
-  children: PropTypes.element,
-  autocomplete: PropTypes.bool,
-  dataSource: PropTypes.arrayOf(PropTypes.string)
-};
+}

--- a/client/components/Footer/Footer.js
+++ b/client/components/Footer/Footer.js
@@ -38,10 +38,11 @@ export default class Footer extends Component {
       </IconButton>
     );
   }
-}
 
-Footer.propTypes = {
-  version: PropTypes.string.isRequired,
-  logging: PropTypes.bool.isRequired,
-  updateLogging: PropTypes.func.isRequired
-};
+  static propTypes = {
+    version: PropTypes.string.isRequired,
+    logging: PropTypes.bool.isRequired,
+    updateLogging: PropTypes.func.isRequired
+  }
+
+}

--- a/client/components/Header/Header.js
+++ b/client/components/Header/Header.js
@@ -74,10 +74,10 @@ export default class Header extends Component {
     );
   }
 
-}
+  static propTypes = {
+    nodeName: PropTypes.string.isRequired,
+    noOfErrors: PropTypes.number.isRequired,
+    disconnected: PropTypes.bool
+  }
 
-Header.propTypes = {
-  nodeName: PropTypes.string.isRequired,
-  noOfErrors: PropTypes.number.isRequired,
-  disconnected: PropTypes.bool
-};
+}

--- a/client/components/JsonEditor/JsonEditor.js
+++ b/client/components/JsonEditor/JsonEditor.js
@@ -75,9 +75,9 @@ export default class JsonEditor extends Component {
     this.props.onChange(parsed, error);
   }
 
-}
+  static propTypes = {
+    onChange: PropTypes.func.isRequired,
+    value: PropTypes.object
+  }
 
-JsonEditor.propTypes = {
-  onChange: PropTypes.func.isRequired,
-  value: PropTypes.object
-};
+}

--- a/client/components/Markdown/Markdown.js
+++ b/client/components/Markdown/Markdown.js
@@ -38,9 +38,9 @@ export default class Marked extends Component {
     return val;
   }
 
-}
+  static propTypes = {
+    val: PropTypes.any,
+    style: PropTypes.object
+  }
 
-Marked.propTypes = {
-  val: PropTypes.any,
-  style: PropTypes.object
-};
+}

--- a/client/components/MiningSettings/MiningSettings.js
+++ b/client/components/MiningSettings/MiningSettings.js
@@ -64,23 +64,24 @@ export default class MiningSettings extends Component {
       </div>
     );
   }
-}
 
-MiningSettings.propTypes = {
-  accounts: PropTypes.arrayOf(PropTypes.string).isRequired,
-  version: PropTypes.string.isRequired,
-  mining: PropTypes.shape({
-    author: PropTypes.string.isRequired,
-    extraData: PropTypes.string.isRequired,
-    defaultExtraData: PropTypes.string.isRequired,
-    minGasPrice: PropTypes.string.isRequired,
-    gasFloorTarget: PropTypes.string.isRequired
-  }).isRequired,
-  actions: PropTypes.shape({
-    modifyMinGasPrice: PropTypes.func.isRequired,
-    modifyAuthor: PropTypes.func.isRequired,
-    modifyGasFloorTarget: PropTypes.func.isRequired,
-    modifyExtraData: PropTypes.func.isRequired,
-    resetExtraData: PropTypes.func.isRequired
-  }).isRequired
-};
+  static propTypes = {
+    accounts: PropTypes.arrayOf(PropTypes.string).isRequired,
+    version: PropTypes.string.isRequired,
+    mining: PropTypes.shape({
+      author: PropTypes.string.isRequired,
+      extraData: PropTypes.string.isRequired,
+      defaultExtraData: PropTypes.string.isRequired,
+      minGasPrice: PropTypes.string.isRequired,
+      gasFloorTarget: PropTypes.string.isRequired
+    }).isRequired,
+    actions: PropTypes.shape({
+      modifyMinGasPrice: PropTypes.func.isRequired,
+      modifyAuthor: PropTypes.func.isRequired,
+      modifyGasFloorTarget: PropTypes.func.isRequired,
+      modifyExtraData: PropTypes.func.isRequired,
+      resetExtraData: PropTypes.func.isRequired
+    }).isRequired
+  }
+
+}

--- a/client/components/MuiThemeProvider/MuiThemeProvider.js
+++ b/client/components/MuiThemeProvider/MuiThemeProvider.js
@@ -18,6 +18,7 @@ const muiTheme = getMuiTheme({
 });
 
 export default class WrappedMuiThemeProvider extends Component {
+
   render () {
     return (
       <MuiThemeProvider muiTheme={muiTheme}>
@@ -27,8 +28,9 @@ export default class WrappedMuiThemeProvider extends Component {
       </MuiThemeProvider>
     );
   }
-}
 
-WrappedMuiThemeProvider.propTypes = {
-  children: PropTypes.object.isRequired
-};
+  static propTypes = {
+    children: PropTypes.object.isRequired
+  }
+
+}

--- a/client/components/Response/Response.js
+++ b/client/components/Response/Response.js
@@ -42,8 +42,9 @@ export default class Response extends Component {
       </span>
     ));
   }
-}
 
-Response.propTypes = {
-  response: PropTypes.any.isRequired
-};
+  static propTypes = {
+    response: PropTypes.any.isRequired
+  }
+
+}

--- a/client/components/RpcCalls/RpcCalls.js
+++ b/client/components/RpcCalls/RpcCalls.js
@@ -17,7 +17,7 @@ import RpcNav from '../RpcNav';
 
 const rpcMethods = _.sortBy(rpcData.methods, 'name');
 
-class RpcCalls extends Component {
+export default class RpcCalls extends Component {
 
   constructor (...args) {
     super(...args);
@@ -304,18 +304,17 @@ class RpcCalls extends Component {
     return `params_${p}`;
   }
 
+  static propTypes = {
+    rpc: PropTypes.shape({
+      prevCalls: PropTypes.array.isRequired,
+      selectedMethod: PropTypes.object.isRequired
+    }).isRequired,
+    actions: PropTypes.shape({
+      fireRpc: PropTypes.func.isRequired,
+      selectRpcMethod: PropTypes.func.isRequired,
+      resetRpcPrevCalls: PropTypes.func.isRequired
+    }).isRequired
+  }
+
 }
-
-RpcCalls.propTypes = {
-  rpc: PropTypes.shape({
-    prevCalls: PropTypes.array.isRequired,
-    selectedMethod: PropTypes.object.isRequired
-  }).isRequired,
-  actions: PropTypes.shape({
-    fireRpc: PropTypes.func.isRequired,
-    selectRpcMethod: PropTypes.func.isRequired,
-    resetRpcPrevCalls: PropTypes.func.isRequired
-  }).isRequired
-};
-
 export default RpcCalls;

--- a/client/components/Status/Status.js
+++ b/client/components/Status/Status.js
@@ -7,7 +7,7 @@ import style from './style.css';
 import Value from '../Value';
 import MiningSettings from '../MiningSettings';
 
-class Status extends Component {
+export default class Status extends Component {
 
   renderNodeName () {
     const { status } = this.props;
@@ -109,27 +109,25 @@ class Status extends Component {
     );
   }
 
+  static propTypes = {
+    mining: PropTypes.object.isRequired,
+    settings: PropTypes.shape({
+      chain: PropTypes.string.isRequired,
+      networkPort: PropTypes.number.isRequired,
+      maxPeers: PropTypes.number.isRequired,
+      rpcEnabled: PropTypes.bool.isRequired,
+      rpcInterface: PropTypes.string.isRequired,
+      rpcPort: PropTypes.number.isRequired
+    }).isRequired,
+    status: PropTypes.shape({
+      name: PropTypes.string,
+      version: PropTypes.string.isRequired,
+      bestBlock: PropTypes.string.isRequired,
+      hashrate: PropTypes.string.isRequired,
+      accounts: PropTypes.arrayOf(PropTypes.string).isRequired,
+      peers: PropTypes.number.isRequired
+    }).isRequired,
+    actions: PropTypes.object.isRequired
+  }
+
 }
-
-Status.propTypes = {
-  mining: PropTypes.object.isRequired,
-  settings: PropTypes.shape({
-    chain: PropTypes.string.isRequired,
-    networkPort: PropTypes.number.isRequired,
-    maxPeers: PropTypes.number.isRequired,
-    rpcEnabled: PropTypes.bool.isRequired,
-    rpcInterface: PropTypes.string.isRequired,
-    rpcPort: PropTypes.number.isRequired
-  }).isRequired,
-  status: PropTypes.shape({
-    name: PropTypes.string,
-    version: PropTypes.string.isRequired,
-    bestBlock: PropTypes.string.isRequired,
-    hashrate: PropTypes.string.isRequired,
-    accounts: PropTypes.arrayOf(PropTypes.string).isRequired,
-    peers: PropTypes.number.isRequired
-  }).isRequired,
-  actions: PropTypes.object.isRequired
-};
-
-export default Status;

--- a/client/components/ToastrContainer/ToastrContainer.js
+++ b/client/components/ToastrContainer/ToastrContainer.js
@@ -34,13 +34,13 @@ export default class ToastrContainer extends Component {
     });
   }
 
-}
+  static propTypes = {
+    toastr: PropTypes.shape({
+      toasts: PropTypes.array.isRequired
+    }).isRequired,
+    actions: PropTypes.shape({
+      removeToast: PropTypes.func.isRequired
+    }).isRequired
+  }
 
-ToastrContainer.propTypes = {
-  toastr: PropTypes.shape({
-    toasts: PropTypes.array.isRequired
-  }).isRequired,
-  actions: PropTypes.shape({
-    removeToast: PropTypes.func.isRequired
-  }).isRequired
-};
+}

--- a/client/components/Value/Value.js
+++ b/client/components/Value/Value.js
@@ -21,9 +21,10 @@ export default class Value extends Component {
       </div>
     );
   }
-}
 
-Value.propTypes = {
-  value: PropTypes.any,
-  children: PropTypes.element
-};
+  static propTypes = {
+    value: PropTypes.any,
+    children: PropTypes.element
+  }
+
+}

--- a/client/containers/AccountsPage/AccountsPage.js
+++ b/client/containers/AccountsPage/AccountsPage.js
@@ -3,6 +3,7 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 
 class AccountsPage extends Component {
+
   render () {
     return (
       <div className='dapp-flex-content'>
@@ -12,12 +13,13 @@ class AccountsPage extends Component {
       </div>
     );
   }
+
+  static propTypes = {
+    logger: PropTypes.object.isRequired,
+    actions: PropTypes.object.isRequired,
+    status: PropTypes.object.isRequired
+  }
 }
-AccountsPage.propTypes = {
-  logger: PropTypes.object.isRequired,
-  actions: PropTypes.object.isRequired,
-  status: PropTypes.object.isRequired
-};
 
 function mapStateToProps (state) {
   return state;

--- a/client/containers/App/App.js
+++ b/client/containers/App/App.js
@@ -39,16 +39,17 @@ class AppContainer extends Component {
       </AnimateChildren>
     );
   }
-}
 
-AppContainer.propTypes = {
-  children: PropTypes.object.isRequired,
-  toastr: PropTypes.object.isRequired,
-  status: PropTypes.object.isRequired,
-  logger: PropTypes.object.isRequired,
-  location: PropTypes.object.isRequired,
-  actions: PropTypes.object.isRequired
-};
+  static propTypes = {
+    children: PropTypes.object.isRequired,
+    toastr: PropTypes.object.isRequired,
+    status: PropTypes.object.isRequired,
+    logger: PropTypes.object.isRequired,
+    location: PropTypes.object.isRequired,
+    actions: PropTypes.object.isRequired
+  }
+
+}
 
 function mapStateToProps (state) {
   return state;

--- a/client/containers/DebugPage/DebugPage.js
+++ b/client/containers/DebugPage/DebugPage.js
@@ -14,11 +14,12 @@ class DebugPage extends Component {
     return <Debug {...this.props} />;
   }
 
+  static propTypes = {
+    actions: PropTypes.object.isRequired,
+    debug: PropTypes.object.isRequired
+  }
+
 }
-DebugPage.propTypes = {
-  actions: PropTypes.object.isRequired,
-  debug: PropTypes.object.isRequired
-};
 
 function mapStateToProps (state) {
   return state;

--- a/client/containers/RpcPage/RpcPage.js
+++ b/client/containers/RpcPage/RpcPage.js
@@ -20,6 +20,12 @@ class RpcPage extends Component {
     );
   }
 
+  static propTypes = {
+    children: PropTypes.object.isRequired,
+    rpc: PropTypes.object.isRequired,
+    actions: PropTypes.object.isRequired
+  }
+
 }
 
 function mapStateToProps (state) {
@@ -31,12 +37,6 @@ function mapDispatchToProps (dispatch) {
     actions: bindActionCreators(extend({}, RpcActions, {copyToClipboard}, {updateLogging}), dispatch)
   };
 }
-
-RpcPage.propTypes = {
-  children: PropTypes.object.isRequired,
-  rpc: PropTypes.object.isRequired,
-  actions: PropTypes.object.isRequired
-};
 
 export default connect(
   mapStateToProps,

--- a/client/containers/StatusPage/StatusPage.js
+++ b/client/containers/StatusPage/StatusPage.js
@@ -12,14 +12,15 @@ class StatusPage extends Component {
   render () {
     return <Status {...this.props} />;
   }
-}
 
-StatusPage.propTypes = {
-  status: PropTypes.object.isRequired,
-  settings: PropTypes.object.isRequired,
-  mining: PropTypes.object.isRequired,
-  actions: PropTypes.object.isRequired
-};
+  static propTypes = {
+    status: PropTypes.object.isRequired,
+    settings: PropTypes.object.isRequired,
+    mining: PropTypes.object.isRequired,
+    actions: PropTypes.object.isRequired
+  }
+
+}
 
 function mapStateToProps (state) {
   return state;

--- a/client/routes.js
+++ b/client/routes.js
@@ -37,8 +37,9 @@ export default class Routes extends Component {
       </Router>
     );
   }
-}
 
-Routes.propTypes = {
-  store: PropTypes.object.isRequired
-};
+  static propTypes = {
+    store: PropTypes.object.isRequired
+  }
+
+}


### PR DESCRIPTION
move all

```
class MyComponent extends Component {
  ...
}

MyComponent.propTypes = {
  ...
};
```

to

```
class MyComponent extends Component {
  ...
  
  static propTypes = {
    ...
  }
}
```

This aligns between projects & ensures coding consistency.